### PR TITLE
add test suite

### DIFF
--- a/cabal-detailed-quickcheck.cabal
+++ b/cabal-detailed-quickcheck.cabal
@@ -14,14 +14,34 @@ category:           Testing
 extra-source-files: CHANGELOG.md
                     README.md
 
-library
-    exposed-modules:    Distribution.TestSuite.QuickCheck
+common basic-config
     build-depends:      
         base >=4&&<5,
         QuickCheck ^>=2.14.2,
         Cabal >=3.6&&<3.9
-    hs-source-dirs:     lib
     default-language:   Haskell2010
+
+library
+    import: basic-config
+    exposed-modules:    Distribution.TestSuite.QuickCheck
+    hs-source-dirs:     lib
+
+Flag test
+  Description: Enable debug support
+  Default:     False
+  Manual:      True
+
+
+Test-Suite test
+    import: basic-config
+    if flag(test)
+      buildable: True
+    else
+      buildable: False
+    hs-source-dirs:   tests
+    build-depends: cabal-detailed-quickcheck
+    type:             detailed-0.9
+    test-module:      Tests
 
 source-repository head
     type:               git

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+module Tests where
+
+import Data.Maybe (maybeToList)
+import Distribution.TestSuite (Test)
+import Distribution.TestSuite.QuickCheck
+import System.CPUTime (getCPUTime)
+import System.IO (hFlush, withFile, IOMode(WriteMode))
+import Test.QuickCheck
+  ( Positive,
+    Testable,
+    getPositive,
+    ioProperty,
+    (===),
+  )
+
+tests :: IO [Test]
+tests = return tests'
+
+normalSettings :: TestArgs
+normalSettings = stdTestArgs {verbosity = Verbose}
+
+getNormalPT :: (Testable prop) => PropertyTest prop -> Test
+getNormalPT = getPropertyTestWith normalSettings
+
+tests' :: [Test]
+tests' =
+  [ getNormalPT
+      PropertyTest
+        { name = "tautology",
+          tags = [],
+          property = \i -> (===) @Int i i
+        },
+    getNormalPT
+      PropertyTest
+        { name = "monotonicity-addition",
+          tags = [],
+          property = \(args@(ap, bp) :: (Positive Int, Positive Int)) ->
+            let a = getPositive ap
+                b = getPositive bp
+                c = a + b
+            in 0 <= c
+        },
+    getNormalPT
+      PropertyTest
+        { name = "monotinicity-time",
+          tags = [],
+          property = ioProperty do
+            a <- getCPUTime
+            withFile "/dev/null" WriteMode $ \handle -> mapM_ print [1..10000] >> hFlush handle
+            b <- getCPUTime
+            return (a < b)
+        }
+  ]


### PR DESCRIPTION
by convention, this pr should come first; as it sets up the tests that subsequent PRs should preserve.